### PR TITLE
feat: move to applications alert on first launch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 #
 # gitignore contributors: remember to update Global/Xcode.gitignore, Objective-C.gitignore & Swift.gitignore
 
+.DS_Store
+
 ## User settings
 xcuserdata/
 

--- a/Whisky.xcodeproj/project.pbxproj
+++ b/Whisky.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		6E5E23EC2A30DBCA00ABC192 /* Hdiutil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E5E23EB2A30DBCA00ABC192 /* Hdiutil.swift */; };
 		6EA2D47E29DDAE5E00C84668 /* BottleRenameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA2D47D29DDAE5E00C84668 /* BottleRenameView.swift */; };
 		6EA2D48529DF130F00C84668 /* ProgramSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EA2D48429DF130F00C84668 /* ProgramSettings.swift */; };
+		EEA5A2462A31DD65008274AE /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = EEA5A2452A31DD65008274AE /* AppDelegate.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -74,6 +75,7 @@
 		6E899D1129CFC41D00A4A083 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		6EA2D47D29DDAE5E00C84668 /* BottleRenameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottleRenameView.swift; sourceTree = "<group>"; };
 		6EA2D48429DF130F00C84668 /* ProgramSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProgramSettings.swift; sourceTree = "<group>"; };
+		EEA5A2452A31DD65008274AE /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -129,6 +131,7 @@
 		6E40495429CCA19C006E3F1B /* Whisky */ = {
 			isa = PBXGroup;
 			children = (
+				EEA5A2452A31DD65008274AE /* AppDelegate.swift */,
 				6E26058729D927F900DDD788 /* Extensions */,
 				6E5197CF29D71FF900CF655E /* Models */,
 				6E5197D029D7200700CF655E /* Utils */,
@@ -307,6 +310,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EEA5A2462A31DD65008274AE /* AppDelegate.swift in Sources */,
 				6E40495829CCA19C006E3F1B /* ContentView.swift in Sources */,
 				6E355E5C29D7830C002D83BE /* InfoView.swift in Sources */,
 				6E5E23EA2A30D6C400ABC192 /* GPTInstallView.swift in Sources */,

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -9,7 +9,7 @@ import Foundation
 import SwiftUI
 
 class AppDelegate: NSObject, NSApplicationDelegate {
-    @AppStorage("hasShownMoveToApplicationsAlerqw") private var hasShownMoveToApplicationsAlert = false
+    @AppStorage("hasShownMoveToApplicationsAlert") private var hasShownMoveToApplicationsAlert = false
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         if !hasShownMoveToApplicationsAlert {
@@ -25,7 +25,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         WhiskyApp.killBottles()
     }
 
-    func showAlertOnFirstLaunch() {
+    private func showAlertOnFirstLaunch() {
         let alert = NSAlert()
         alert.messageText = "Would you like to move Whisky to your Applications folder?"
         alert.informativeText = "In some cases app couldn't function properly from Downloads folder"

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -27,10 +27,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func showAlertOnFirstLaunch() {
         let alert = NSAlert()
-        alert.messageText = "Would you like to move Whisky to your Applications folder?"
-        alert.informativeText = "In some cases app couldn't function properly from Downloads folder"
-        alert.addButton(withTitle: "Move to Applications")
-        alert.addButton(withTitle: "Don't Move")
+        alert.messageText = NSLocalizedString("showAlertOnFirstLaunch.messageText", comment: "")
+        alert.informativeText = NSLocalizedString("showAlertOnFirstLaunch.informativeText", comment: "")
+        alert.addButton(withTitle: NSLocalizedString("showAlertOnFirstLaunch.button.moveToApplications", comment: ""))
+        alert.addButton(withTitle: NSLocalizedString("showAlertOnFirstLaunch.button.dontMove", comment: ""))
 
         let response = alert.runModal()
 

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -13,7 +13,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         if !hasShownMoveToApplicationsAlert {
-            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+            DispatchQueue.main.asyncAfter(deadline: .now()) {
                 NSApp.activate(ignoringOtherApps: true)
                 self.showAlertOnFirstLaunch()
                 self.hasShownMoveToApplicationsAlert = true

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -37,7 +37,8 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         if response == .alertFirstButtonReturn {
             let appURL = Bundle.main.bundleURL
 
-            guard let applicationsURL = FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first else {
+            guard let applicationsURL = FileManager.default.urls(for: .applicationDirectory, 
+                                                                 in: .localDomainMask).first else {
                 return
             }
 

--- a/Whisky/AppDelegate.swift
+++ b/Whisky/AppDelegate.swift
@@ -35,17 +35,15 @@ class AppDelegate: NSObject, NSApplicationDelegate {
         let response = alert.runModal()
 
         if response == .alertFirstButtonReturn {
-            let fileManager = FileManager.default
             let appURL = Bundle.main.bundleURL
 
-            guard let applicationsURL = fileManager.urls(for: .applicationDirectory, in: .localDomainMask).first else {
+            guard let applicationsURL = FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask).first else {
                 return
             }
 
             let destinationURL = applicationsURL.appendingPathComponent(appURL.lastPathComponent)
             do {
-                _ = try fileManager.replaceItemAt(destinationURL, withItemAt: appURL)
-
+                _ = try FileManager.default.replaceItemAt(destinationURL, withItemAt: appURL)
                 NSWorkspace.shared.open(destinationURL)
             } catch {
                 print("Failed to move the app: \(error)")

--- a/Whisky/Utils/GPT.swift
+++ b/Whisky/Utils/GPT.swift
@@ -9,7 +9,11 @@ import Foundation
 
 // GPT = Game Porting Toolkit
 class GPT {
-    static let libFolder: URL = (Bundle.main.resourceURL ?? URL(fileURLWithPath: ""))
+    static let applicationFolder: URL = FileManager.default.urls(for: .applicationDirectory, in: .localDomainMask)[0]
+    static let libFolder: URL = applicationFolder
+        .appendingPathComponent("Whisky.app")
+        .appendingPathComponent("Contents")
+        .appendingPathComponent("Resources")
         .appendingPathComponent("Libraries")
         .appendingPathComponent("Wine")
         .appendingPathComponent("lib")

--- a/Whisky/Utils/GPT.swift
+++ b/Whisky/Utils/GPT.swift
@@ -28,23 +28,24 @@ class GPT {
     static func install(url: URL) {
         do {
             let path = try Hdiutil.mount(url: url) + "/lib"
+            let fileManager = FileManager.default
 
-            if let pathEnumerator = FileManager.default.enumerator(atPath: path) {
+            if let pathEnumerator = fileManager.enumerator(atPath: path) {
                 while let relativePath = pathEnumerator.nextObject() as? String {
                     let subItemAt = URL(fileURLWithPath: path).appendingPathComponent(relativePath).path
                     let subItemTo = libFolder.appendingPathComponent(relativePath).path
 
                     if isDir(atPath: subItemAt) {
                         if !isDir(atPath: subItemTo) {
-                            try FileManager.default.createDirectory(atPath: subItemTo,
+                            try fileManager.createDirectory(atPath: subItemTo,
                                                                     withIntermediateDirectories: true)
                         }
                     } else {
                         if isFile(atPath: subItemTo) {
-                            try FileManager.default.removeItem(atPath: subItemTo)
+                            try fileManager.removeItem(atPath: subItemTo)
                         }
 
-                        try FileManager.default.copyItem(atPath: subItemAt, toPath: subItemTo)
+                        try fileManager.copyItem(atPath: subItemAt, toPath: subItemTo)
                     }
                 }
                 print("GPT Installed")

--- a/Whisky/Utils/GPT.swift
+++ b/Whisky/Utils/GPT.swift
@@ -28,24 +28,23 @@ class GPT {
     static func install(url: URL) {
         do {
             let path = try Hdiutil.mount(url: url) + "/lib"
-            let fileManager = FileManager.default
 
-            if let pathEnumerator = fileManager.enumerator(atPath: path) {
+            if let pathEnumerator = FileManager.default.enumerator(atPath: path) {
                 while let relativePath = pathEnumerator.nextObject() as? String {
                     let subItemAt = URL(fileURLWithPath: path).appendingPathComponent(relativePath).path
                     let subItemTo = libFolder.appendingPathComponent(relativePath).path
 
                     if isDir(atPath: subItemAt) {
                         if !isDir(atPath: subItemTo) {
-                            try fileManager.createDirectory(atPath: subItemTo,
+                            try FileManager.default.createDirectory(atPath: subItemTo,
                                                                     withIntermediateDirectories: true)
                         }
                     } else {
                         if isFile(atPath: subItemTo) {
-                            try fileManager.removeItem(atPath: subItemTo)
+                            try FileManager.default.removeItem(atPath: subItemTo)
                         }
 
-                        try fileManager.copyItem(atPath: subItemAt, toPath: subItemTo)
+                        try FileManager.default.copyItem(atPath: subItemAt, toPath: subItemTo)
                     }
                 }
                 print("GPT Installed")

--- a/Whisky/Views/AppDelegate.swift
+++ b/Whisky/Views/AppDelegate.swift
@@ -1,0 +1,55 @@
+//
+//  AppDelegate.swift
+//  Whisky
+//
+//  Created by Viacheslav Shkliarov on 08.06.2023.
+//
+
+import Foundation
+import SwiftUI
+
+class AppDelegate: NSObject, NSApplicationDelegate {
+    @AppStorage("hasShownMoveToApplicationsAlerqw") private var hasShownMoveToApplicationsAlert = false
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        if !hasShownMoveToApplicationsAlert {
+            DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                NSApp.activate(ignoringOtherApps: true)
+                self.showAlertOnFirstLaunch()
+                self.hasShownMoveToApplicationsAlert = true
+            }
+        }
+    }
+
+    func applicationWillTerminate(_ notification: Notification) {
+        WhiskyApp.killBottles()
+    }
+
+    func showAlertOnFirstLaunch() {
+        let alert = NSAlert()
+        alert.messageText = "Would you like to move Whisky to your Applications folder?"
+        alert.informativeText = "In some cases app couldn't function properly from Downloads folder"
+        alert.addButton(withTitle: "Move to Applications")
+        alert.addButton(withTitle: "Don't Move")
+
+        let response = alert.runModal()
+
+        if response == .alertFirstButtonReturn {
+            let fileManager = FileManager.default
+            let appURL = Bundle.main.bundleURL
+
+            guard let applicationsURL = fileManager.urls(for: .applicationDirectory, in: .localDomainMask).first else {
+                return
+            }
+
+            let destinationURL = applicationsURL.appendingPathComponent(appURL.lastPathComponent)
+            do {
+                _ = try fileManager.replaceItemAt(destinationURL, withItemAt: appURL)
+
+                NSWorkspace.shared.open(destinationURL)
+            } catch {
+                print("Failed to move the app: \(error)")
+            }
+        }
+    }
+}

--- a/Whisky/Views/GPTInstallView.swift
+++ b/Whisky/Views/GPTInstallView.swift
@@ -29,6 +29,7 @@ struct GPTInstallView: View {
                     .animation(.easeInOut(duration: 0.2), value: dragOver)
             }
         }
+        .fixedSize()
         .padding()
         .onDrop(of: ["public.file-url"], isTargeted: $dragOver) { providers -> Bool in
             providers.first?.loadDataRepresentation(forTypeIdentifier: "public.file-url",

--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -8,12 +8,6 @@
 import SwiftUI
 import Sparkle
 
-class AppDelegate: NSObject, NSApplicationDelegate {
-    func applicationWillTerminate(_ notification: Notification) {
-        WhiskyApp.killBottles()
-    }
-}
-
 @main
 struct WhiskyApp: App {
     @NSApplicationDelegateAdaptor(AppDelegate.self) var appDelegate

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -52,3 +52,8 @@
 
 "check.updates" = "Check for Updates...";
 "kill.bottles" = "Kill All Bottles...";
+
+"showAlertOnFirstLaunch.messageText" = "Would you like to move Whisky to your Applications folder?";
+"showAlertOnFirstLaunch.informativeText" = "In some cases app couldn't function properly from Downloads folder";
+"showAlertOnFirstLaunch.button.moveToApplications" = "Move to Applications";
+"showAlertOnFirstLaunch.button.dontMove" = "Don't Move";

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -54,6 +54,6 @@
 "kill.bottles" = "Kill All Bottles...";
 
 "showAlertOnFirstLaunch.messageText" = "Would you like to move Whisky to your Applications folder?";
-"showAlertOnFirstLaunch.informativeText" = "In some cases app couldn't function properly from Downloads folder";
+"showAlertOnFirstLaunch.informativeText" = "In some cases, Whisky wont't be able to function properly from a different folder";
 "showAlertOnFirstLaunch.button.moveToApplications" = "Move to Applications";
 "showAlertOnFirstLaunch.button.dontMove" = "Don't Move";


### PR DESCRIPTION
There are a few issues when opening the app from the folder it has been downloaded to, e.g. ~/Downloads
1. Sparkle cannot update the application if it is launched from the folder where it has been downloaded.
2. Dropping the .dmg file into the drop area has no effect if the app is not in the Applications folder. (This fixes issue #25.)

To address this issue, I have implemented a gentle alert for the user upon the first app launch, advising them to move the application to the Applications folder. This solution works seamlessly, and the user does not need to restart the application after clicking "Move to Applications" button.

<img width="372" alt="Screenshot 2023-06-08 at 13 38 39" src="https://github.com/IsaacMarovitz/Whisky/assets/59966858/8e24a529-e82b-4d9b-bd82-5158ea2bfd4e">
