### PR TITLE
Add bottle name validation

### DIFF
--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -59,4 +59,15 @@ class BottleVM: ObservableObject {
             }
         }
     }
+
+    func validateBottleName(bottleName: String) -> (isInvalidName: Bool, description: String) {
+        if bottleName.isEmpty {
+            return (true, NSLocalizedString("create.warning.emptyName", comment: ""))
+        }
+
+        if bottles.contains(where: {$0.name == bottleName}) {
+            return (true, NSLocalizedString("create.warning.alreadyExistsName", comment: ""))
+        }
+        return (false, "")
+    }
 }

--- a/Whisky/Views/BottleCreationView.swift
+++ b/Whisky/Views/BottleCreationView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct BottleCreationView: View {
     @State var newBottleName: String = ""
     @State var newBottleVersion: WinVersion = .win10
+    @State var invalidBottleNameDescription: String = ""
+    @State var invalidBottleName: Bool = false
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -20,11 +22,24 @@ struct BottleCreationView: View {
                 Spacer()
             }
             Divider()
-            HStack {
+            HStack(alignment: .top) {
                 Text("create.name")
                 Spacer()
-                TextField("", text: $newBottleName)
-                    .frame(width: 180)
+                VStack(alignment: .leading) {
+                    TextField("", text: $newBottleName)
+                        .onChange(of: newBottleName) { _ in
+                            invalidBottleName = false
+                        }
+                    if invalidBottleName {
+                        Text(invalidBottleNameDescription)
+                            .foregroundColor(.red)
+                            .font(.system(.footnote))
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .lineLimit(2)
+                    }
+                }
+                .frame(width: 180)
             }
             HStack {
                 Text("create.win")
@@ -45,6 +60,10 @@ struct BottleCreationView: View {
                 }
                 .keyboardShortcut(.cancelAction)
                 Button("create.create") {
+                    (invalidBottleName, invalidBottleNameDescription) = BottleVM.shared.validateBottleName(bottleName: newBottleName)
+                    if invalidBottleName {
+                        return
+                    }
                     BottleVM.shared.createNewBottle(bottleName: newBottleName,
                                                     winVersion: newBottleVersion)
                     dismiss()
@@ -53,7 +72,7 @@ struct BottleCreationView: View {
             }
         }
         .padding()
-        .frame(width: 350, height: 150)
+        .frame(width: 370, height: 180)
     }
 }
 

--- a/Whisky/Views/BottleRenameView.swift
+++ b/Whisky/Views/BottleRenameView.swift
@@ -10,6 +10,8 @@ import SwiftUI
 struct BottleRenameView: View {
     let bottle: Bottle
     @State var newBottleName: String = ""
+    @State var invalidBottleNameDescription: String = ""
+    @State var invalidBottleName: Bool = false
     @Environment(\.dismiss) var dismiss
 
     var body: some View {
@@ -20,11 +22,25 @@ struct BottleRenameView: View {
                 Spacer()
             }
             Divider()
-            HStack {
+            HStack(alignment: .top) {
                 Text("rename.name")
                 Spacer()
-                TextField("", text: $newBottleName)
-                    .frame(width: 180)
+                VStack(alignment: .leading) {
+                    TextField("", text: $newBottleName)
+                        .onChange(of: newBottleName) { _ in
+                            invalidBottleName = false
+                        }
+                    if invalidBottleName {
+                        Text(invalidBottleNameDescription)
+                            .foregroundColor(.red)
+                            .font(.system(.footnote))
+                            .multilineTextAlignment(.leading)
+                            .fixedSize(horizontal: false, vertical: true)
+                            .lineLimit(2)
+
+                    }
+                }
+                .frame(width: 180)
             }
             Spacer()
             HStack {
@@ -34,6 +50,10 @@ struct BottleRenameView: View {
                 }
                 .keyboardShortcut(.cancelAction)
                 Button("rename.rename") {
+                    (invalidBottleName, invalidBottleNameDescription) = BottleVM.shared.validateBottleName(bottleName: newBottleName)
+                    if invalidBottleName {
+                        return
+                    }
                     bottle.rename(newName: newBottleName)
                     dismiss()
                 }
@@ -41,7 +61,7 @@ struct BottleRenameView: View {
             }
         }
         .padding()
-        .frame(width: 350, height: 150)
+        .frame(width: 370, height: 150)
         .onAppear {
             newBottleName = bottle.name
         }

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -48,6 +48,8 @@
 "create.win" = "Windows version:";
 "create.cancel" = "Cancel";
 "create.create" = "Create";
+"create.warning.emptyName" = "The Bottle name can't be empty";
+"create.warning.alreadyExistsName" = "A Bottle with this name already exists";
 
 "rename.title" = "Rename bottle";
 "rename.name" = "New name:";


### PR DESCRIPTION
Currently there are no Bottle name checks during the creation and renaming. So, now it's possible to create a bottle without a name, which then uses then uses the `Bottles` dir as its destination, or create/rename to a name that already exists. I've added a check for the name validity, and a warning label.

https://github.com/IsaacMarovitz/Whisky/assets/5073663/0e792396-8728-4b84-ac99-d9ff8a339330

