### PR TITLE
feat: Add Control Panel button

### DIFF
--- a/Whisky/Utils/Wine.swift
+++ b/Whisky/Utils/Wine.swift
@@ -110,6 +110,11 @@ class Wine {
     }
 
     @discardableResult
+    static func control(bottle: Bottle) async throws -> String {
+        return try await run(["control"], bottle: bottle)
+    }
+
+    @discardableResult
     static func regedit(bottle: Bottle) async throws -> String {
         return try await run(["regedit"], bottle: bottle)
     }

--- a/Whisky/Views/Bottle Views/ConfigView.swift
+++ b/Whisky/Views/Bottle Views/ConfigView.swift
@@ -48,6 +48,15 @@ struct ConfigView: View {
             .formStyle(.grouped)
             HStack {
                 Spacer()
+                Button("config.control") {
+                    Task(priority: .userInitiated) {
+                        do {
+                            try await Wine.control(bottle: bottle)
+                        } catch {
+                            print("Failed to launch control")
+                        }
+                    }
+                }
                 Button("config.regedit") {
                     Task(priority: .userInitiated) {
                         do {

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -24,6 +24,7 @@
 "config.metalTrace" = "Metal Trace";
 "config.metalTrace.info" = "Allows you to capture GPU workload in Xcode";
 "config.esync" = "ESync";
+"config.control" = "Open Control Panel";
 "config.regedit" = "Open Registry Editor";
 "config.winecfg" = "Open Wine Configuration";
 

--- a/Whisky/zh-Hans.lproj/Localizable.strings
+++ b/Whisky/zh-Hans.lproj/Localizable.strings
@@ -24,6 +24,7 @@
 "config.metalTrace" = "Metal Trace";
 "config.metalTrace.info" = "允许你在Xcode中捕获GPU工作负载";
 "config.esync" = "ESync";
+"config.control" = "打开控制面板";
 "config.winecfg" = "打开Wine配置";
 
 "program.title" = "已安装的程序";


### PR DESCRIPTION
Add a button to open the built-in Control Panel of wine. Useful for managing installed applications and game controllers.

Here are some screenshots of this PR:
<img width="1012" alt="截屏2023-06-13 14 01 28" src="https://github.com/IsaacMarovitz/Whisky/assets/44023928/8a8a36ff-0450-420e-b9a3-dee3288f8067">
<img width="1184" alt="截屏2023-06-13 13 52 19" src="https://github.com/IsaacMarovitz/Whisky/assets/44023928/9e337040-0ce2-4087-992e-4998bfa29cdf">
<img width="776" alt="截屏2023-06-13 13 52 27" src="https://github.com/IsaacMarovitz/Whisky/assets/44023928/db54de2d-21bd-48e9-bd9d-e85d5f7205ac">
<img width="776" alt="截屏2023-06-13 13 53 27" src="https://github.com/IsaacMarovitz/Whisky/assets/44023928/c17b177b-ad00-4f1f-ab58-41f3f0ad7b70">
