### PR TITLE
fix: start the run dialog at the root of the bottle instead of $whatever

### DIFF
--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -73,6 +73,7 @@ struct BottleView: View {
                     panel.canChooseFiles = true
                     panel.allowedContentTypes = [UTType.exe,
                                                  UTType(importedAs: "com.microsoft.msi-installer")]
+                    panel.directoryURL = bottle.url
                     panel.begin { result in
                         programLoading = true
                         Task(priority: .userInitiated) {


### PR DESCRIPTION
Put the Run button at the root of the Wine bottle, making it easier to launch apps from inside the bottle if needed