### PR TITLE
Add a Quit All button to Kill All Wine Processes

### DIFF
--- a/Whisky/Models/Bottle.swift
+++ b/Whisky/Models/Bottle.swift
@@ -32,6 +32,12 @@ public class Bottle: Hashable {
         NSWorkspace.shared.activateFileViewerSelecting([cDrive])
     }
 
+    func quitAllInstances(of processName: String) {
+            let task = Process()
+            task.launchPath = "/usr/bin/pkill"
+            task.arguments = ["-f", processName]
+            task.launch()
+        }
     @discardableResult
     func updateStartMenuPrograms() -> [ShellLinkHeader] {
         let globalStartMenu = url

--- a/Whisky/Models/Bottle.swift
+++ b/Whisky/Models/Bottle.swift
@@ -34,8 +34,8 @@ public class Bottle: Hashable {
 
     func quitAllInstances(of processName: String) {
             let task = Process()
-            task.launchPath = "/usr/bin/pkill"
-            task.arguments = ["-f", processName]
+            task.launchPath = "/usr/bin/killall"
+            task.arguments = [processName]
             task.launch()
         }
     @discardableResult

--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -123,13 +123,11 @@ struct BottleView: View {
             }
             Spacer()
             HStack {
-                Button(action: {
+                Button("button.quitAll") {
                     let wineProcesses = ["wine64-preloader", "wineserver"]
                     for processName in wineProcesses {
                         bottle.quitAllInstances(of: processName)
                     }
-                }) {
-                    Text("Quit All")
                 }
                 Spacer()
                 Button("button.cDrive") {

--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -123,6 +123,14 @@ struct BottleView: View {
             }
             Spacer()
             HStack {
+                Button(action: {
+                    let wineProcesses = ["wine64-preloader", "wineserver"]
+                    for processName in wineProcesses {
+                        bottle.quitAllInstances(of: processName)
+                    }
+                }) {
+                    Text("Quit All")
+                }
                 Spacer()
                 Button("button.cDrive") {
                     bottle.openCDrive()

--- a/Whisky/en.lproj/Localizable.strings
+++ b/Whisky/en.lproj/Localizable.strings
@@ -9,6 +9,7 @@
 "main.noneSelected" = "Select a bottle";
 "main.createFirst" = "Create your first bottle to get started";
 
+"button.quitAll" = "Quit All";
 "button.cDrive" = "Open C Drive";
 "button.showInFinder" = "Show in Finder";
 "button.run" = "Run...";


### PR DESCRIPTION
Button kills all `wine64-preloader` and `wineserver` processes.

<img width="810" alt="Screenshot 2023-06-27 at 10 15 27 PM" src="https://github.com/IsaacMarovitz/Whisky/assets/127471645/772ff8b6-8791-4968-8b7c-091fed675fc4">