### PR TITLE
Trigger starred programs refresh on the main bottle view

### DIFF
--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -102,7 +102,7 @@ struct BottleView: View {
                             Label("tab.config", systemImage: "gearshape.fill")
                         }
                         NavigationLink {
-                            ProgramsView(bottle: bottle)
+                            ProgramsView(bottle: bottle, reloadStartMenu: $loadStartMenu)
                         } label: {
                             Label("tab.programs", systemImage: "macwindow")
                         }

--- a/Whisky/Views/Bottle Views/ProgramsView.swift
+++ b/Whisky/Views/Bottle Views/ProgramsView.swift
@@ -13,6 +13,7 @@ struct ProgramsView: View {
     // We don't actually care about the value
     // This just provides a way to trigger a refresh
     @State var resortPrograms: Bool = false
+    @Binding var reloadStartMenu: Bool
 
     var body: some View {
         NavigationStack {
@@ -35,6 +36,7 @@ struct ProgramsView: View {
                 sortPrograms()
             }
             .onChange(of: resortPrograms) { _ in
+                reloadStartMenu.toggle()
                 sortPrograms()
             }
         }
@@ -101,7 +103,8 @@ struct ProgramItemView: View {
 }
 
 struct ProgramsView_Previews: PreviewProvider {
+    @State private static var reloadStartMenu: Bool = false
     static var previews: some View {
-        ProgramsView(bottle: Bottle())
+        ProgramsView(bottle: Bottle(), reloadStartMenu: $reloadStartMenu)
     }
 }


### PR DESCRIPTION
For some reason the Bottle View starred list is not updated, when you toggle favourite apps. This forcefully triggers the refresh.

Previously:

https://github.com/IsaacMarovitz/Whisky/assets/5073663/ea9b0c9d-1abd-4888-9e02-104caadafdc1


Now:

https://github.com/IsaacMarovitz/Whisky/assets/5073663/291c6168-8489-48a2-b4cf-7504df3d2b9c

