### PR TITLE
Add support for Windows Shortcuts

### DIFF
--- a/Whisky/Info.plist
+++ b/Whisky/Info.plist
@@ -27,6 +27,25 @@
 				</array>
 			</dict>
 		</dict>
+		<dict>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+			</array>
+			<key>UTTypeDescription</key>
+			<string>Microsoft Windows Shortcut</string>
+			<key>UTTypeIcons</key>
+			<dict/>
+			<key>UTTypeIdentifier</key>
+			<string>com.microsoft.windows-shortcut</string>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>lnk</string>
+				</array>
+			</dict>
+		</dict>
 	</array>
 	<key>WineBinaryVersion</key>
 	<integer>4</integer>

--- a/Whisky/Views/Bottle Views/BottleView.swift
+++ b/Whisky/Views/Bottle Views/BottleView.swift
@@ -133,7 +133,8 @@ struct BottleView: View {
                     panel.canChooseDirectories = false
                     panel.canChooseFiles = true
                     panel.allowedContentTypes = [UTType.exe,
-                                                 UTType(importedAs: "com.microsoft.msi-installer")]
+                                                 UTType(importedAs: "com.microsoft.msi-installer"),
+                                                  UTType(importedAs: "com.microsoft.windows-shortcut")]
                     panel.directoryURL = bottle.url.appendingPathComponent("drive_c")
                     panel.begin { result in
                         programLoading = true


### PR DESCRIPTION
This pull request allows Windows Shortcuts to be used to start Wine.

When running a game with the standalone `gameportingtoolkit` binary the game needed the Shortcut to work (when installed to the Desktop).

Whisky can run the same executable from the `Program Files (x86)` directory, but the same error occurs when run from the Whisky Programs menu. Reverting 08acc0b makes it work though.