### PR TITLE
Revamp bottle loading and add bottle validation

### DIFF
--- a/Whisky/Views/WhiskyApp.swift
+++ b/Whisky/Views/WhiskyApp.swift
@@ -46,18 +46,8 @@ struct WhiskyApp: App {
                     panel.begin { result in
                         if result == .OK {
                             if let url = panel.urls.first {
-                                let bottleMetadata = url
-                                    .appendingPathComponent("Metadata")
-                                    .appendingPathExtension("plist")
-                                    .path()
-
-                                if FileManager.default.fileExists(atPath: bottleMetadata) {
-                                    // Legacy files
-                                    let bottle = BottleSettings(bottleURL: url)
-                                    bottle.encode()
-                                }
-
                                 BottleVM.shared.bottlesList.paths.append(url)
+                                BottleVM.shared.bottlesList.encode()
                                 BottleVM.shared.loadBottles()
                             }
                         }


### PR DESCRIPTION
Previously, if the bottle directory was moved/removed, the plist wasn't updated respectively. This checks if the bottle is valid, meaning if it exists and has a valid `Metadata.plist` file. Additionally, it allows importing legacy bottles.

Hopefully, this also fixes #255.