### PR TITLE
Replace deprecated path attribute

### DIFF
--- a/Whisky/Models/ProgramSettings.swift
+++ b/Whisky/Models/ProgramSettings.swift
@@ -45,7 +45,7 @@ class ProgramSettings {
                                     .appendingPathComponent(name)
                                     .appendingPathExtension("plist")
 
-        if !FileManager.default.fileExists(atPath: settingsFolder.path) {
+        if !FileManager.default.fileExists(atPath: settingsFolder.path(percentEncoded: false)) {
             do {
                 try FileManager.default.createDirectory(at: settingsFolder, withIntermediateDirectories: true)
             } catch {

--- a/Whisky/View Models/BottleVM.swift
+++ b/Whisky/View Models/BottleVM.swift
@@ -69,7 +69,7 @@ class BottleVM: ObservableObject {
         let bottleMetadata = bottleURL
             .appendingPathComponent("Metadata")
             .appendingPathExtension("plist")
-            .path()
+            .path(percentEncoded: false)
 
         if FileManager.default.fileExists(atPath: bottleMetadata) {
             let bottle = BottleSettings(bottleURL: bottleURL)
@@ -86,12 +86,14 @@ class BottleVM: ObservableObject {
         Task.detached { @MainActor in
             var bottleId: Bottle? = .none
             do {
-                if !FileManager.default.fileExists(atPath: BottleVM.bottleDir.path) {
-                    try FileManager.default.createDirectory(atPath: BottleVM.bottleDir.path,
+                let bottleDirPath = BottleVM.bottleDir.path(percentEncoded: false)
+                if !FileManager.default.fileExists(atPath: bottleDirPath) {
+                    try FileManager.default.createDirectory(atPath: bottleDirPath,
                                                             withIntermediateDirectories: true)
                 }
 
-                try FileManager.default.createDirectory(atPath: newBottleDir.path, withIntermediateDirectories: true)
+                try FileManager.default.createDirectory(atPath: newBottleDir.path(percentEncoded: false),
+                                                        withIntermediateDirectories: true)
                 let bottle = Bottle(bottleUrl: newBottleDir, inFlight: true)
                 bottleId = .some(bottle)
 


### PR DESCRIPTION
It seems that the [URL.path](https://developer.apple.com/documentation/foundation/url/1779812-path) attribute will be deprecated, and instead should be replaced by` URL.path(percentEncoded: false)`

This also fixes #287 